### PR TITLE
Use 0 offset in file_get_contents

### DIFF
--- a/src/WebThumbnailer/Application/WebAccess/WebAccessPHP.php
+++ b/src/WebThumbnailer/Application/WebAccess/WebAccessPHP.php
@@ -42,7 +42,7 @@ class WebAccessPHP implements WebAccess
         }
 
         $context = stream_context_create($context);
-        $content = file_get_contents($finalUrl, false, $context, -1, $maxBytes);
+        $content = file_get_contents($finalUrl, false, $context, 0, $maxBytes);
 
         return array($headers, $content);
     }


### PR DESCRIPTION
file_get_contents was changed in php 7.1.0 to support negative offsets. This changes the meaning of -1 from previous version.