### PR TITLE
Fix "PHP message: TypeError: get_headers(): Argument #2 ($associative…

### DIFF
--- a/src/Application/WebAccess/WebAccessPHP.php
+++ b/src/Application/WebAccess/WebAccessPHP.php
@@ -62,11 +62,11 @@ class WebAccessPHP implements WebAccess
     {
         stream_context_set_default($this->getContext($timeout));
 
-        $headers = @get_headers($url, 1);
+        $headers = @get_headers($url, true);
         // Some hosts don't like fulluri request, some requires it...
         if ($headers === false) {
             stream_context_set_default($this->getContext($timeout, false));
-            $headers = @get_headers($url, 1);
+            $headers = @get_headers($url, true);
         }
 
         // Headers found, redirection found, and limit not reached.


### PR DESCRIPTION
The message "PHP message: TypeError: get_headers(): Argument https://github.com/shaarli/Shaarli/pull/2 ($associative) must be of type bool, int given" pops from time to time in php logs, fix get_headers() call to comply with requirement.